### PR TITLE
Fix uninitialized variable that causes bad syntax

### DIFF
--- a/bin2c.c
+++ b/bin2c.c
@@ -85,6 +85,8 @@ main ( int argc, char* argv[] )
     }
 
     ident = argv[3];
+    
+    need_comma = 0;
 
     fprintf (f_output, "const char %s[%i] = {", ident, file_size);
     for (i = 0; i < file_size; ++i)


### PR DESCRIPTION
`need_comma` is uninitialized but the code assumes it begins with a value of `0`.  This will work sometimes, but occasionally results in output with bad syntax (caused by an extra comma).
